### PR TITLE
update set output

### DIFF
--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Check for changes in grafana json file
         id: check_changes
         run: |
-          git diff --quiet $GITHUB_WORKSPACE/grafana/output.json || echo "::set-output name=changes::true"
+          git diff --quiet $GITHUB_WORKSPACE/grafana/output.json || echo "changes=true" >> $GITHUB_OUTPUT
+          
 
       - name: Update Grafana dashboard with new json
         #if: steps.check_changes.outputs.changes == 'true'
@@ -30,7 +31,7 @@ jobs:
         run: python $GITHUB_WORKSPACE/grafana/update_grafana_dashboard.py
 
       - name: Commit grafana json file after update version
-        #if: steps.check_changes.outputs.changes == 'true'
+        if: steps.check_changes.outputs.changes == 'true'
         run: |
           echo ${{ steps.check_changes.outputs.changes }}
           git checkout main

--- a/grafana/output.json
+++ b/grafana/output.json
@@ -9110,7 +9110,7 @@
     ]
   },
   "time": {
-    "from": "now-45d",
+    "from": "now-5d",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/